### PR TITLE
Use native promise and global export

### DIFF
--- a/dexie-batch.js
+++ b/dexie-batch.js
@@ -1,5 +1,3 @@
-const Promise = require('dexie').Promise
-
 module.exports = class DexieBatch {
   constructor(opts) {
     assertValidOptions(opts)

--- a/dexie-batch.js
+++ b/dexie-batch.js
@@ -1,4 +1,4 @@
-module.exports = class DexieBatch {
+window.DexieBatch = class DexieBatch {
   constructor(opts) {
     assertValidOptions(opts)
     this.opts = opts


### PR DESCRIPTION
Hi @raphinesse,

thank you for creating `dexie-batch`!

At [Wire](https://github.com/wireapp) we would love to use your tool in our [web app](https://github.com/wireapp/wire-webapp), but since you are using the (in Dexie >= 2.0 deprecated) `Dexie.Promise` function and `module.exports` without distributing a packed version, it's not working for us (and probably many others).

We'd love to see this tool in action with native promises and in the browser, what do you think?

Also see: https://github.com/dfahlander/Dexie.js/issues/317#issue-178349994.